### PR TITLE
[Harvest] Config manager implementation + tests

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,17 +7,19 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": [
+    "include": [
       "**/*.js",
       "**/*.ts",
       "**/*.jsx",
       "**/*.tsx",
-      "**/*.json",
-      "!!**/node_modules",
-      "!!**/necromancy_graveyard",
-      "!!**/CLAUDINE_SUPREME_CONSCIOUSNESS_NEXUS",
-      "!!**/.poly_gluttony",
-      "!!**/*.zst"
+      "**/*.json"
+    ],
+    "ignore": [
+      "**/node_modules",
+      "**/necromancy_graveyard",
+      "**/CLAUDINE_SUPREME_CONSCIOUSNESS_NEXUS",
+      "**/.poly_gluttony",
+      "**/*.zst"
     ]
   },
   "formatter": {

--- a/claudine-cli/src/core/config/config-manager.ts
+++ b/claudine-cli/src/core/config/config-manager.ts
@@ -1,0 +1,346 @@
+/**
+ * Configuration Manager for Claudine CLI
+ *
+ * Manages .poly_gluttony configuration:
+ * - Loads config from .poly_gluttony/config.json
+ * - Searches upward from cwd to find .poly_gluttony/
+ * - Initializes config with default structure
+ * - Saves and updates config
+ * - Handles errors (missing dirs, corrupted JSON, permissions)
+ * - Resolves PowerShell script paths
+ *
+ * @module core/config/config-manager
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { z } from "zod";
+
+/**
+ * Configuration schema using Zod for runtime validation
+ */
+const CLITConfigSchema = z.object({
+  version: z.string(),
+  polygluttonyRoot: z.string(),
+  workspaceRoot: z.string(),
+  scripts: z.object({
+    claudineENV: z.string().optional(),
+    claudineENV_F: z.string().optional(),
+    pwshGoddess: z.string().optional(),
+  }),
+  languages: z.array(z.string()),
+  environments: z.record(z.any()).optional(),
+  lastUpdated: z.string().optional(),
+});
+
+/**
+ * Configuration type inferred from schema
+ */
+export type CLITConfig = z.infer<typeof CLITConfigSchema>;
+
+/**
+ * Configuration directory name
+ */
+export const CONFIG_DIR_NAME = ".poly_gluttony";
+
+/**
+ * Configuration file name
+ */
+export const CONFIG_FILE_NAME = "config.json";
+
+/**
+ * Default PowerShell script names
+ */
+export const DEFAULT_SCRIPTS = {
+  claudineENV: "claudineENV.ps1",
+  claudineENV_F: "claudineENV_F.ps1",
+  pwshGoddess: "pwshGoddess.ps1",
+};
+
+/**
+ * Default languages supported
+ */
+export const DEFAULT_LANGUAGES = ["python", "rust", "ruby", "javascript", "typescript", "go", "bun"];
+
+/**
+ * Error thrown when .poly_gluttony directory is not found
+ */
+export class ConfigNotFoundError extends Error {
+  constructor(message = "Configuration directory not found") {
+    super(message);
+    this.name = "ConfigNotFoundError";
+  }
+}
+
+/**
+ * Error thrown when config.json is corrupted or invalid
+ */
+export class ConfigValidationError extends Error {
+  constructor(message = "Invalid configuration") {
+    super(message);
+    this.name = "ConfigValidationError";
+  }
+}
+
+/**
+ * Error thrown when there are permission issues
+ */
+export class ConfigPermissionError extends Error {
+  constructor(message = "Permission denied") {
+    super(message);
+    this.name = "ConfigPermissionError";
+  }
+}
+
+/**
+ * Find .poly_gluttony directory by searching upward from startDir
+ *
+ * @param startDir - Starting directory for search (defaults to cwd)
+ * @returns Path to .poly_gluttony directory
+ * @throws {ConfigNotFoundError} If directory not found
+ */
+export function findPolygluttonyRoot(startDir: string = process.cwd()): string {
+  let currentDir = path.resolve(startDir);
+  const root = path.parse(currentDir).root;
+
+  while (currentDir !== root) {
+    const configDir = path.join(currentDir, CONFIG_DIR_NAME);
+
+    if (fs.existsSync(configDir)) {
+      try {
+        const stats = fs.statSync(configDir);
+        if (stats.isDirectory()) {
+          return configDir;
+        }
+      } catch (_error) {
+        // Permission error or other issue, continue searching
+      }
+    }
+
+    // Move up one directory
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      // Reached the root
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  throw new ConfigNotFoundError(`Could not find ${CONFIG_DIR_NAME} directory in ${startDir} or any parent directory`);
+}
+
+/**
+ * Load configuration from .poly_gluttony/config.json
+ *
+ * @param startDir - Starting directory for search (defaults to cwd)
+ * @returns Validated configuration object
+ * @throws {ConfigNotFoundError} If .poly_gluttony not found
+ * @throws {ConfigValidationError} If config.json is corrupted or invalid
+ * @throws {ConfigPermissionError} If permission denied
+ */
+export function loadConfig(startDir: string = process.cwd()): CLITConfig {
+  // Find .poly_gluttony directory
+  const polygluttonyRoot = findPolygluttonyRoot(startDir);
+  const configPath = path.join(polygluttonyRoot, CONFIG_FILE_NAME);
+
+  // Check if config.json exists
+  if (!fs.existsSync(configPath)) {
+    throw new ConfigNotFoundError(`Configuration file not found: ${configPath}`);
+  }
+
+  // Read config file
+  let configData: string;
+  try {
+    configData = fs.readFileSync(configPath, "utf-8");
+  } catch (error: unknown) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "EACCES") {
+      throw new ConfigPermissionError(`Permission denied reading config: ${configPath}`);
+    }
+    throw error;
+  }
+
+  // Parse JSON
+  let parsedConfig: unknown;
+  try {
+    parsedConfig = JSON.parse(configData);
+  } catch (_error) {
+    throw new ConfigValidationError(`Corrupted JSON in config file: ${configPath}`);
+  }
+
+  // Validate config with Zod
+  try {
+    return CLITConfigSchema.parse(parsedConfig);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const issues = error.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ");
+      throw new ConfigValidationError(`Invalid configuration: ${issues}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Resolve path to a PowerShell script
+ *
+ * @param scriptName - Name of the script to find
+ * @param polygluttonyRoot - Root directory to search in
+ * @returns Path to script if found, undefined otherwise
+ */
+export function resolveScriptPath(scriptName: string, polygluttonyRoot: string): string | undefined {
+  // Check if script exists in polygluttonyRoot
+  const scriptPath = path.join(polygluttonyRoot, scriptName);
+  if (fs.existsSync(scriptPath)) {
+    return scriptPath;
+  }
+
+  // Check in scripts subdirectory
+  const scriptsPath = path.join(polygluttonyRoot, "scripts", scriptName);
+  if (fs.existsSync(scriptsPath)) {
+    return scriptsPath;
+  }
+
+  return undefined;
+}
+
+/**
+ * Initialize .poly_gluttony directory structure and config
+ *
+ * @param targetDir - Directory to create .poly_gluttony in (defaults to cwd)
+ * @param force - Force overwrite existing config (defaults to false)
+ * @returns Created configuration object
+ * @throws {ConfigPermissionError} If permission denied
+ */
+export function initConfig(targetDir: string = process.cwd(), force = false): CLITConfig {
+  const polygluttonyRoot = path.join(targetDir, CONFIG_DIR_NAME);
+  const configPath = path.join(polygluttonyRoot, CONFIG_FILE_NAME);
+
+  // Check if config already exists
+  if (!force && fs.existsSync(configPath)) {
+    throw new Error(`Configuration already exists at ${configPath}. Use force=true to overwrite.`);
+  }
+
+  // Create .poly_gluttony directory structure
+  try {
+    fs.mkdirSync(polygluttonyRoot, { recursive: true });
+    fs.mkdirSync(path.join(polygluttonyRoot, "environments"), { recursive: true });
+    fs.mkdirSync(path.join(polygluttonyRoot, "scripts"), { recursive: true });
+    fs.mkdirSync(path.join(polygluttonyRoot, "health"), { recursive: true });
+  } catch (error: unknown) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "EACCES") {
+      throw new ConfigPermissionError(`Permission denied creating directory: ${polygluttonyRoot}`);
+    }
+    throw error;
+  }
+
+  // Detect script paths
+  const scripts: Record<string, string | undefined> = {};
+  for (const [key, scriptName] of Object.entries(DEFAULT_SCRIPTS)) {
+    const scriptPath = resolveScriptPath(scriptName, polygluttonyRoot);
+    if (scriptPath) {
+      scripts[key] = scriptPath;
+    }
+  }
+
+  // Create default config
+  const config: CLITConfig = {
+    version: "1.0.0",
+    polygluttonyRoot,
+    workspaceRoot: targetDir,
+    scripts,
+    languages: DEFAULT_LANGUAGES,
+    lastUpdated: new Date().toISOString(),
+  };
+
+  // Save config
+  saveConfig(config);
+
+  return config;
+}
+
+/**
+ * Save configuration to disk
+ *
+ * @param config - Configuration object to save
+ * @throws {ConfigPermissionError} If permission denied
+ */
+export function saveConfig(config: CLITConfig): void {
+  const configPath = path.join(config.polygluttonyRoot, CONFIG_FILE_NAME);
+
+  // Ensure directory exists
+  try {
+    fs.mkdirSync(config.polygluttonyRoot, { recursive: true });
+  } catch (error: unknown) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "EACCES") {
+      throw new ConfigPermissionError(`Permission denied creating directory: ${config.polygluttonyRoot}`);
+    }
+    throw error;
+  }
+
+  // Write config file
+  try {
+    const configData = JSON.stringify(config, null, 2);
+    fs.writeFileSync(configPath, configData, "utf-8");
+  } catch (error: unknown) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "EACCES") {
+      throw new ConfigPermissionError(`Permission denied writing config: ${configPath}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Update configuration with partial updates
+ *
+ * @param updates - Partial configuration updates
+ * @param startDir - Starting directory for search (defaults to cwd)
+ * @returns Updated configuration object
+ * @throws {ConfigNotFoundError} If config not found
+ * @throws {ConfigPermissionError} If permission denied
+ */
+export function updateConfig(updates: Partial<CLITConfig>, startDir: string = process.cwd()): CLITConfig {
+  // Load existing config
+  const config = loadConfig(startDir);
+
+  // Merge updates
+  const updatedConfig: CLITConfig = {
+    ...config,
+    ...updates,
+    scripts: {
+      ...config.scripts,
+      ...updates.scripts,
+    },
+    lastUpdated: new Date().toISOString(),
+  };
+
+  // Validate updated config
+  const validated = CLITConfigSchema.parse(updatedConfig);
+
+  // Save updated config
+  saveConfig(validated);
+
+  return validated;
+}
+
+/**
+ * Validate configuration object
+ *
+ * @param config - Configuration object to validate
+ * @returns True if valid
+ * @throws {ConfigValidationError} If invalid
+ */
+export function validateConfig(config: unknown): boolean {
+  try {
+    CLITConfigSchema.parse(config);
+    return true;
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const issues = error.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ");
+      throw new ConfigValidationError(`Invalid configuration: ${issues}`);
+    }
+    throw error;
+  }
+}

--- a/claudine-cli/tests/config-manager.test.ts
+++ b/claudine-cli/tests/config-manager.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Comprehensive test suite for config-manager
+ *
+ * Tests:
+ * - Config loading with upward directory search
+ * - Config initialization with default structure
+ * - Config saving and updating
+ * - Error handling (missing dirs, corrupted JSON, permissions)
+ * - Script resolution
+ * - Validation
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  type CLITConfig,
+  CONFIG_DIR_NAME,
+  CONFIG_FILE_NAME,
+  ConfigNotFoundError,
+  ConfigValidationError,
+  DEFAULT_LANGUAGES,
+  findPolygluttonyRoot,
+  initConfig,
+  loadConfig,
+  resolveScriptPath,
+  saveConfig,
+  updateConfig,
+  validateConfig,
+} from "../src/core/config/config-manager";
+
+// Test fixture directories
+let testRootDir: string;
+let testPolygluttonyDir: string;
+
+/**
+ * Create a test fixture directory structure
+ */
+function createTestFixture(): void {
+  testRootDir = fs.mkdtempSync(path.join(os.tmpdir(), "claudine-test-"));
+  testPolygluttonyDir = path.join(testRootDir, CONFIG_DIR_NAME);
+  fs.mkdirSync(testPolygluttonyDir, { recursive: true });
+}
+
+/**
+ * Clean up test fixture directories
+ */
+function cleanupTestFixture(): void {
+  if (testRootDir && fs.existsSync(testRootDir)) {
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Create a valid config.json file in test fixture
+ */
+function createValidConfig(customValues?: Partial<CLITConfig>): CLITConfig {
+  const config: CLITConfig = {
+    version: "1.0.0",
+    polygluttonyRoot: testPolygluttonyDir,
+    workspaceRoot: testRootDir,
+    scripts: {
+      claudineENV: path.join(testPolygluttonyDir, "claudineENV.ps1"),
+      claudineENV_F: path.join(testPolygluttonyDir, "claudineENV_F.ps1"),
+    },
+    languages: DEFAULT_LANGUAGES,
+    ...customValues,
+  };
+
+  const configPath = path.join(testPolygluttonyDir, CONFIG_FILE_NAME);
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf-8");
+
+  return config;
+}
+
+describe("Config Loading Tests", () => {
+  beforeEach(() => {
+    createTestFixture();
+  });
+
+  afterEach(() => {
+    cleanupTestFixture();
+  });
+
+  it("should load valid config from .poly_gluttony/config.json", () => {
+    const expectedConfig = createValidConfig();
+    const loadedConfig = loadConfig(testRootDir);
+
+    expect(loadedConfig.version).toBe(expectedConfig.version);
+    expect(loadedConfig.polygluttonyRoot).toBe(expectedConfig.polygluttonyRoot);
+    expect(loadedConfig.workspaceRoot).toBe(expectedConfig.workspaceRoot);
+    expect(loadedConfig.languages).toEqual(expectedConfig.languages);
+  });
+
+  it("should find .poly_gluttony by searching upward from nested directory", () => {
+    createValidConfig();
+
+    // Create nested directory structure
+    const nestedDir = path.join(testRootDir, "src", "commands", "deep");
+    fs.mkdirSync(nestedDir, { recursive: true });
+
+    // Load config from deeply nested directory
+    const config = loadConfig(nestedDir);
+    expect(config.polygluttonyRoot).toBe(testPolygluttonyDir);
+  });
+
+  it("should return valid CLITConfig with all required fields", () => {
+    createValidConfig();
+    const config = loadConfig(testRootDir);
+
+    expect(config).toHaveProperty("version");
+    expect(config).toHaveProperty("polygluttonyRoot");
+    expect(config).toHaveProperty("workspaceRoot");
+    expect(config).toHaveProperty("scripts");
+    expect(config).toHaveProperty("languages");
+    expect(typeof config.version).toBe("string");
+    expect(typeof config.polygluttonyRoot).toBe("string");
+    expect(typeof config.workspaceRoot).toBe("string");
+    expect(typeof config.scripts).toBe("object");
+    expect(Array.isArray(config.languages)).toBe(true);
+  });
+
+  it("should throw ConfigNotFoundError when .poly_gluttony not found", () => {
+    // Don't create config, use a different temp directory
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "claudine-empty-"));
+
+    try {
+      expect(() => loadConfig(emptyDir)).toThrow(ConfigNotFoundError);
+    } finally {
+      fs.rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should throw ConfigNotFoundError when config.json missing", () => {
+    // Create .poly_gluttony but no config.json
+    expect(() => loadConfig(testRootDir)).toThrow(ConfigNotFoundError);
+    expect(() => loadConfig(testRootDir)).toThrow("Configuration file not found");
+  });
+
+  it("should handle corrupted JSON gracefully", () => {
+    const configPath = path.join(testPolygluttonyDir, CONFIG_FILE_NAME);
+    fs.writeFileSync(configPath, "{ invalid json content }", "utf-8");
+
+    expect(() => loadConfig(testRootDir)).toThrow(ConfigValidationError);
+    expect(() => loadConfig(testRootDir)).toThrow("Corrupted JSON");
+  });
+
+  it("should throw ConfigValidationError for missing required fields", () => {
+    const configPath = path.join(testPolygluttonyDir, CONFIG_FILE_NAME);
+    const invalidConfig = {
+      version: "1.0.0",
+      // Missing required fields
+    };
+    fs.writeFileSync(configPath, JSON.stringify(invalidConfig), "utf-8");
+
+    expect(() => loadConfig(testRootDir)).toThrow(ConfigValidationError);
+  });
+});
+
+describe("Config Initialization Tests", () => {
+  beforeEach(() => {
+    testRootDir = fs.mkdtempSync(path.join(os.tmpdir(), "claudine-init-"));
+  });
+
+  afterEach(() => {
+    cleanupTestFixture();
+  });
+
+  it("should create .poly_gluttony directory structure", () => {
+    initConfig(testRootDir);
+
+    const polygluttonyDir = path.join(testRootDir, CONFIG_DIR_NAME);
+    expect(fs.existsSync(polygluttonyDir)).toBe(true);
+    expect(fs.statSync(polygluttonyDir).isDirectory()).toBe(true);
+  });
+
+  it("should create required subdirectories", () => {
+    initConfig(testRootDir);
+
+    const polygluttonyDir = path.join(testRootDir, CONFIG_DIR_NAME);
+    const environmentsDir = path.join(polygluttonyDir, "environments");
+    const scriptsDir = path.join(polygluttonyDir, "scripts");
+    const healthDir = path.join(polygluttonyDir, "health");
+
+    expect(fs.existsSync(environmentsDir)).toBe(true);
+    expect(fs.existsSync(scriptsDir)).toBe(true);
+    expect(fs.existsSync(healthDir)).toBe(true);
+    expect(fs.statSync(environmentsDir).isDirectory()).toBe(true);
+    expect(fs.statSync(scriptsDir).isDirectory()).toBe(true);
+    expect(fs.statSync(healthDir).isDirectory()).toBe(true);
+  });
+
+  it("should generate valid config.json with defaults", () => {
+    const config = initConfig(testRootDir);
+
+    expect(config.version).toBe("1.0.0");
+    expect(config.polygluttonyRoot).toBe(path.join(testRootDir, CONFIG_DIR_NAME));
+    expect(config.workspaceRoot).toBe(testRootDir);
+    expect(config.languages).toEqual(DEFAULT_LANGUAGES);
+    expect(config).toHaveProperty("lastUpdated");
+  });
+
+  it("should detect script paths when scripts exist", () => {
+    // Create scripts first
+    const polygluttonyDir = path.join(testRootDir, CONFIG_DIR_NAME);
+    fs.mkdirSync(polygluttonyDir, { recursive: true });
+
+    const script1Path = path.join(polygluttonyDir, "claudineENV.ps1");
+    const script2Path = path.join(polygluttonyDir, "claudineENV_F.ps1");
+    fs.writeFileSync(script1Path, "# PowerShell script", "utf-8");
+    fs.writeFileSync(script2Path, "# PowerShell script", "utf-8");
+
+    const config = initConfig(testRootDir, true);
+
+    expect(config.scripts.claudineENV).toBe(script1Path);
+    expect(config.scripts.claudineENV_F).toBe(script2Path);
+  });
+
+  it("should not overwrite existing config without force flag", () => {
+    // Create initial config
+    initConfig(testRootDir);
+
+    // Try to init again without force
+    expect(() => initConfig(testRootDir, false)).toThrow("Configuration already exists");
+  });
+
+  it("should overwrite existing config with force flag", () => {
+    // Create initial config
+    const config1 = initConfig(testRootDir);
+    const version1 = config1.version;
+
+    // Wait a tiny bit to ensure different timestamp
+    // (In real scenarios, this would be different)
+
+    // Overwrite with force
+    const config2 = initConfig(testRootDir, true);
+    expect(config2.version).toBe(version1); // Same version
+    expect(config2.polygluttonyRoot).toBe(config1.polygluttonyRoot);
+  });
+});
+
+describe("Config Persistence Tests", () => {
+  beforeEach(() => {
+    createTestFixture();
+  });
+
+  afterEach(() => {
+    cleanupTestFixture();
+  });
+
+  it("should write config to disk successfully", () => {
+    const config: CLITConfig = {
+      version: "1.0.0",
+      polygluttonyRoot: testPolygluttonyDir,
+      workspaceRoot: testRootDir,
+      scripts: {},
+      languages: DEFAULT_LANGUAGES,
+    };
+
+    saveConfig(config);
+
+    const configPath = path.join(testPolygluttonyDir, CONFIG_FILE_NAME);
+    expect(fs.existsSync(configPath)).toBe(true);
+
+    const savedData = fs.readFileSync(configPath, "utf-8");
+    const savedConfig = JSON.parse(savedData);
+    expect(savedConfig.version).toBe(config.version);
+  });
+
+  it("should merge partial updates correctly", () => {
+    createValidConfig({ version: "1.0.0" });
+
+    const updates = {
+      version: "1.1.0",
+    };
+
+    const updatedConfig = updateConfig(updates, testRootDir);
+
+    expect(updatedConfig.version).toBe("1.1.0");
+    expect(updatedConfig.polygluttonyRoot).toBe(testPolygluttonyDir); // Preserved
+    expect(updatedConfig.languages).toEqual(DEFAULT_LANGUAGES); // Preserved
+  });
+
+  it("should preserve existing fields when updating subset", () => {
+    const originalConfig = createValidConfig({
+      version: "1.0.0",
+      languages: ["python", "rust"],
+    });
+
+    const updates = {
+      version: "2.0.0",
+    };
+
+    const updatedConfig = updateConfig(updates, testRootDir);
+
+    expect(updatedConfig.version).toBe("2.0.0"); // Updated
+    expect(updatedConfig.languages).toEqual(["python", "rust"]); // Preserved
+    expect(updatedConfig.workspaceRoot).toBe(originalConfig.workspaceRoot); // Preserved
+  });
+
+  it("should update lastUpdated timestamp", () => {
+    createValidConfig();
+
+    const updates = {
+      version: "1.1.0",
+    };
+
+    const updatedConfig = updateConfig(updates, testRootDir);
+    expect(updatedConfig).toHaveProperty("lastUpdated");
+    expect(typeof updatedConfig.lastUpdated).toBe("string");
+  });
+
+  it("should merge script updates correctly", () => {
+    createValidConfig({
+      scripts: {
+        claudineENV: "old-path.ps1",
+      },
+    });
+
+    const updates = {
+      scripts: {
+        claudineENV_F: "new-script.ps1",
+      },
+    };
+
+    const updatedConfig = updateConfig(updates, testRootDir);
+
+    expect(updatedConfig.scripts.claudineENV).toBe("old-path.ps1"); // Preserved
+    expect(updatedConfig.scripts.claudineENV_F).toBe("new-script.ps1"); // Added
+  });
+});
+
+describe("Validation Tests", () => {
+  it("should accept valid config", () => {
+    const validConfig = {
+      version: "1.0.0",
+      polygluttonyRoot: "/path/to/.poly_gluttony",
+      workspaceRoot: "/path/to/workspace",
+      scripts: {},
+      languages: ["python", "rust"],
+    };
+
+    expect(validateConfig(validConfig)).toBe(true);
+  });
+
+  it("should reject config missing version", () => {
+    const invalidConfig = {
+      // Missing version
+      polygluttonyRoot: "/path/to/.poly_gluttony",
+      workspaceRoot: "/path/to/workspace",
+      scripts: {},
+      languages: ["python"],
+    };
+
+    expect(() => validateConfig(invalidConfig)).toThrow(ConfigValidationError);
+  });
+
+  it("should reject config missing polygluttonyRoot", () => {
+    const invalidConfig = {
+      version: "1.0.0",
+      // Missing polygluttonyRoot
+      workspaceRoot: "/path/to/workspace",
+      scripts: {},
+      languages: ["python"],
+    };
+
+    expect(() => validateConfig(invalidConfig)).toThrow(ConfigValidationError);
+  });
+
+  it("should reject config missing workspaceRoot", () => {
+    const invalidConfig = {
+      version: "1.0.0",
+      polygluttonyRoot: "/path/to/.poly_gluttony",
+      // Missing workspaceRoot
+      scripts: {},
+      languages: ["python"],
+    };
+
+    expect(() => validateConfig(invalidConfig)).toThrow(ConfigValidationError);
+  });
+
+  it("should reject config missing scripts", () => {
+    const invalidConfig = {
+      version: "1.0.0",
+      polygluttonyRoot: "/path/to/.poly_gluttony",
+      workspaceRoot: "/path/to/workspace",
+      // Missing scripts
+      languages: ["python"],
+    };
+
+    expect(() => validateConfig(invalidConfig)).toThrow(ConfigValidationError);
+  });
+
+  it("should reject config missing languages", () => {
+    const invalidConfig = {
+      version: "1.0.0",
+      polygluttonyRoot: "/path/to/.poly_gluttony",
+      workspaceRoot: "/path/to/workspace",
+      scripts: {},
+      // Missing languages
+    };
+
+    expect(() => validateConfig(invalidConfig)).toThrow(ConfigValidationError);
+  });
+
+  it("should reject config with invalid types", () => {
+    const invalidConfig = {
+      version: 123, // Should be string
+      polygluttonyRoot: "/path/to/.poly_gluttony",
+      workspaceRoot: "/path/to/workspace",
+      scripts: {},
+      languages: ["python"],
+    };
+
+    expect(() => validateConfig(invalidConfig)).toThrow(ConfigValidationError);
+  });
+});
+
+describe("Script Resolution Tests", () => {
+  beforeEach(() => {
+    createTestFixture();
+  });
+
+  afterEach(() => {
+    cleanupTestFixture();
+  });
+
+  it("should find script in polygluttonyRoot", () => {
+    const scriptPath = path.join(testPolygluttonyDir, "claudineENV.ps1");
+    fs.writeFileSync(scriptPath, "# PowerShell script", "utf-8");
+
+    const resolved = resolveScriptPath("claudineENV.ps1", testPolygluttonyDir);
+    expect(resolved).toBe(scriptPath);
+  });
+
+  it("should find script in scripts subdirectory", () => {
+    const scriptsDir = path.join(testPolygluttonyDir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+
+    const scriptPath = path.join(scriptsDir, "pwshGoddess.ps1");
+    fs.writeFileSync(scriptPath, "# PowerShell script", "utf-8");
+
+    const resolved = resolveScriptPath("pwshGoddess.ps1", testPolygluttonyDir);
+    expect(resolved).toBe(scriptPath);
+  });
+
+  it("should return undefined for missing script", () => {
+    const resolved = resolveScriptPath("nonexistent.ps1", testPolygluttonyDir);
+    expect(resolved).toBeUndefined();
+  });
+
+  it("should prefer script in root over scripts subdirectory", () => {
+    // Create script in both locations
+    const rootScriptPath = path.join(testPolygluttonyDir, "test.ps1");
+    const scriptsDir = path.join(testPolygluttonyDir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const subScriptPath = path.join(scriptsDir, "test.ps1");
+
+    fs.writeFileSync(rootScriptPath, "# Root script", "utf-8");
+    fs.writeFileSync(subScriptPath, "# Sub script", "utf-8");
+
+    const resolved = resolveScriptPath("test.ps1", testPolygluttonyDir);
+    expect(resolved).toBe(rootScriptPath); // Should prefer root
+  });
+});
+
+describe("findPolygluttonyRoot Tests", () => {
+  beforeEach(() => {
+    createTestFixture();
+  });
+
+  afterEach(() => {
+    cleanupTestFixture();
+  });
+
+  it("should find .poly_gluttony in current directory", () => {
+    const found = findPolygluttonyRoot(testRootDir);
+    expect(found).toBe(testPolygluttonyDir);
+  });
+
+  it("should find .poly_gluttony in parent directory", () => {
+    const childDir = path.join(testRootDir, "child");
+    fs.mkdirSync(childDir, { recursive: true });
+
+    const found = findPolygluttonyRoot(childDir);
+    expect(found).toBe(testPolygluttonyDir);
+  });
+
+  it("should find .poly_gluttony multiple levels up", () => {
+    const deepDir = path.join(testRootDir, "a", "b", "c", "d");
+    fs.mkdirSync(deepDir, { recursive: true });
+
+    const found = findPolygluttonyRoot(deepDir);
+    expect(found).toBe(testPolygluttonyDir);
+  });
+
+  it("should throw ConfigNotFoundError when not found", () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "claudine-nofind-"));
+
+    try {
+      expect(() => findPolygluttonyRoot(emptyDir)).toThrow(ConfigNotFoundError);
+    } finally {
+      fs.rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Harvest PR

Copilot branch \copilot/implement-config-system-tests\ contains a complete config-manager subsystem.

### What's here
- \claudine-cli/src/core/config/config-manager.ts\ (+346 lines) — full config manager implementation
- \claudine-cli/tests/config-manager.test.ts\ (+507 lines) — test suite

### Context
This branch is 2 commits ahead, 21 behind main. The implementation + tests are the harvest target — not the merge base. Review the new files for architectural fit before rebasing.

### Action needed
1. Review config-manager.ts API surface
2. Rebase onto main (resolve lockfile/test infra conflicts)
3. Merge or cherry-pick the two core files

*Wet-Paper-to-Gold archaeology — this branch is raw gold.*