### PR TITLE
[Harvest] Config/detector/orchestrator wiring

### DIFF
--- a/claudine-cli/src/core/config/index.ts
+++ b/claudine-cli/src/core/config/index.ts
@@ -13,6 +13,8 @@ export interface ConfigOptions {
 
 /**
  * Load configuration from .poly_gluttony directory
+ * Note: This function is async to maintain consistency with the orchestrator's
+ * async execution model and to allow for future async operations (e.g., remote config).
  */
 export async function loadConfig(options: ConfigOptions = {}): Promise<ClaudineConfig> {
   return Promise.resolve().then(() => {
@@ -48,6 +50,8 @@ export async function loadConfig(options: ConfigOptions = {}): Promise<ClaudineC
 
 /**
  * Initialize configuration directory
+ * Note: This function is async to maintain consistency with the orchestrator's
+ * async execution model and to allow for future async operations.
  */
 export async function initConfig(options: ConfigOptions = {}): Promise<ClaudineConfig> {
   return Promise.resolve().then(() => {
@@ -76,6 +80,8 @@ export async function initConfig(options: ConfigOptions = {}): Promise<ClaudineC
 
 /**
  * Get current configuration
+ * This is a convenience method that calls loadConfig() with default options.
+ * Provided as a separate function to match the tool registration in orchestrator.
  */
 export async function getConfig(): Promise<ClaudineConfig> {
   return await loadConfig();

--- a/claudine-cli/src/core/config/index.ts
+++ b/claudine-cli/src/core/config/index.ts
@@ -1,0 +1,82 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface ClaudineConfig {
+  version: string;
+  polygluttonyRoot: string;
+  workspaceRoot: string;
+}
+
+export interface ConfigOptions {
+  workspaceRoot?: string;
+}
+
+/**
+ * Load configuration from .poly_gluttony directory
+ */
+export async function loadConfig(options: ConfigOptions = {}): Promise<ClaudineConfig> {
+  return Promise.resolve().then(() => {
+    const workspaceRoot = options.workspaceRoot || process.cwd();
+    const polygluttonyRoot = path.join(workspaceRoot, ".poly_gluttony");
+
+    // Check if .poly_gluttony exists
+    if (!fs.existsSync(polygluttonyRoot)) {
+      throw new Error(`Configuration directory not found: ${polygluttonyRoot}`);
+    }
+
+    const configPath = path.join(polygluttonyRoot, "config.json");
+
+    // If config.json exists, load it
+    if (fs.existsSync(configPath)) {
+      const configData = fs.readFileSync(configPath, "utf-8");
+      const config = JSON.parse(configData);
+      return {
+        ...config,
+        polygluttonyRoot,
+        workspaceRoot,
+      };
+    }
+
+    // Return default config if file doesn't exist
+    return {
+      version: "1.0.0",
+      polygluttonyRoot,
+      workspaceRoot,
+    };
+  });
+}
+
+/**
+ * Initialize configuration directory
+ */
+export async function initConfig(options: ConfigOptions = {}): Promise<ClaudineConfig> {
+  return Promise.resolve().then(() => {
+    const workspaceRoot = options.workspaceRoot || process.cwd();
+    const polygluttonyRoot = path.join(workspaceRoot, ".poly_gluttony");
+
+    // Create .poly_gluttony directory if it doesn't exist
+    if (!fs.existsSync(polygluttonyRoot)) {
+      fs.mkdirSync(polygluttonyRoot, { recursive: true });
+    }
+
+    // Create default config
+    const config: ClaudineConfig = {
+      version: "1.0.0",
+      polygluttonyRoot,
+      workspaceRoot,
+    };
+
+    // Write config.json
+    const configPath = path.join(polygluttonyRoot, "config.json");
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf-8");
+
+    return config;
+  });
+}
+
+/**
+ * Get current configuration
+ */
+export async function getConfig(): Promise<ClaudineConfig> {
+  return await loadConfig();
+}

--- a/claudine-cli/src/core/detector/index.ts
+++ b/claudine-cli/src/core/detector/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Environment detection module
+ */
+
+export interface DetectionResult {
+  platform: string;
+  arch: string;
+  runtime: string;
+}
+
+/**
+ * Detect current environment
+ */
+export async function detect(): Promise<DetectionResult> {
+  const result = await Promise.resolve({
+    platform: process.platform,
+    arch: process.arch,
+    runtime: "bun",
+  });
+  return result;
+}

--- a/claudine-cli/src/core/detector/index.ts
+++ b/claudine-cli/src/core/detector/index.ts
@@ -10,6 +10,8 @@ export interface DetectionResult {
 
 /**
  * Detect current environment
+ * Note: This function is async to maintain consistency with the orchestrator's
+ * async execution model and to allow for future async detection operations.
  */
 export async function detect(): Promise<DetectionResult> {
   const result = await Promise.resolve({

--- a/claudine-cli/src/core/orchestrator/orchestrator.ts
+++ b/claudine-cli/src/core/orchestrator/orchestrator.ts
@@ -1,0 +1,161 @@
+import * as path from "node:path";
+
+export interface ToolDefinition {
+  name: string;
+  module: string;
+  function: string;
+  description?: string;
+}
+
+export interface InvokeOptions {
+  params?: Record<string, unknown>;
+}
+
+export interface InvokeResult {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+// Mapping of module names to their file paths
+const MODULE_MAPPING: Record<string, string> = {
+  "@claudine/detector": "../detector/index.js",
+  "@claudine/config": "../config/index.js",
+};
+
+// Tool registry
+const toolRegistry: Map<string, ToolDefinition> = new Map();
+
+/**
+ * Register a tool with the orchestrator
+ */
+export function registerTool(toolDef: ToolDefinition): void {
+  toolRegistry.set(toolDef.name, toolDef);
+}
+
+/**
+ * Initialize orchestrator with default tools
+ */
+export function initOrchestrator(): void {
+  // Register config tools
+  registerTool({
+    name: "config-load",
+    module: "@claudine/config",
+    function: "loadConfig",
+    description: "Load configuration from .poly_gluttony directory",
+  });
+
+  registerTool({
+    name: "config-init",
+    module: "@claudine/config",
+    function: "initConfig",
+    description: "Initialize configuration directory",
+  });
+
+  registerTool({
+    name: "config-get",
+    module: "@claudine/config",
+    function: "getConfig",
+    description: "Get current configuration",
+  });
+
+  // Register detector tool
+  registerTool({
+    name: "detect",
+    module: "@claudine/detector",
+    function: "detect",
+    description: "Detect current environment",
+  });
+}
+
+/**
+ * Execute a native module function
+ */
+async function executeNative(toolDef: ToolDefinition, options: InvokeOptions = {}): Promise<unknown> {
+  const modulePath = MODULE_MAPPING[toolDef.module];
+
+  if (!modulePath) {
+    throw new Error(`Module not found: ${toolDef.module}`);
+  }
+
+  // Resolve the module path relative to this file
+  const resolvedPath = path.join(__dirname, modulePath);
+
+  try {
+    // Dynamic import of the module
+    const module = await import(resolvedPath);
+    const fn = module[toolDef.function];
+
+    if (!fn || typeof fn !== "function") {
+      throw new Error(`Function not found: ${toolDef.function} in ${toolDef.module}`);
+    }
+
+    // Execute the function based on module type
+    let data: unknown;
+
+    switch (toolDef.module) {
+      case "@claudine/config":
+        if (toolDef.function === "loadConfig") {
+          const configOptions = options.params || {};
+          data = await fn(configOptions);
+        } else if (toolDef.function === "initConfig") {
+          const initOptions = options.params || {};
+          data = await fn(initOptions);
+        } else if (toolDef.function === "getConfig") {
+          data = await fn();
+        }
+        break;
+
+      case "@claudine/detector":
+        data = await fn();
+        break;
+
+      default:
+        // Default: call function with params
+        data = await fn(options.params);
+        break;
+    }
+
+    return data;
+  } catch (error) {
+    throw new Error(`Failed to execute ${toolDef.module}.${toolDef.function}: ${error}`);
+  }
+}
+
+/**
+ * Invoke a tool by name
+ */
+export async function invoke(toolName: string, options: InvokeOptions = {}): Promise<InvokeResult> {
+  try {
+    const toolDef = toolRegistry.get(toolName);
+
+    if (!toolDef) {
+      return {
+        success: false,
+        error: `Tool not found: ${toolName}`,
+      };
+    }
+
+    const data = await executeNative(toolDef, options);
+
+    return {
+      success: true,
+      data,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Get all registered tools
+ */
+export function getRegisteredTools(): ToolDefinition[] {
+  return Array.from(toolRegistry.values());
+}
+
+// Initialize on module load
+initOrchestrator();

--- a/claudine-cli/src/core/orchestrator/orchestrator.ts
+++ b/claudine-cli/src/core/orchestrator/orchestrator.ts
@@ -19,8 +19,8 @@ export interface InvokeResult {
 
 // Mapping of module names to their file paths
 const MODULE_MAPPING: Record<string, string> = {
-  "@claudine/detector": "../detector/index.js",
-  "@claudine/config": "../config/index.js",
+  "@claudine/detector": "../detector/index",
+  "@claudine/config": "../config/index",
 };
 
 // Tool registry

--- a/claudine-cli/tests/orchestration.test.ts
+++ b/claudine-cli/tests/orchestration.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as orchestrator from "../src/core/orchestrator/orchestrator";
+
+describe("Config Tool Integration", () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    // Create a temporary directory for testing
+    tempDir = path.join(os.tmpdir(), `config-test-${Date.now()}`);
+    fs.mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    // Cleanup
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should load config via orchestrator", async () => {
+    // First init config in temp directory
+    const initResult = await orchestrator.invoke("config-init", {
+      params: { workspaceRoot: tempDir },
+    });
+
+    expect(initResult.success).toBe(true);
+    expect(initResult.data).toBeDefined();
+
+    // Now load the config
+    const result = await orchestrator.invoke("config-load", {
+      params: { workspaceRoot: tempDir },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveProperty("version");
+    expect(result.data).toHaveProperty("polygluttonyRoot");
+    expect(result.data.version).toBe("1.0.0");
+    expect(result.data.polygluttonyRoot).toBe(path.join(tempDir, ".poly_gluttony"));
+  });
+
+  it("should init config via orchestrator", async () => {
+    const tempDir2 = path.join(os.tmpdir(), `config-test-init-${Date.now()}`);
+
+    const result = await orchestrator.invoke("config-init", {
+      params: { workspaceRoot: tempDir2 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveProperty("polygluttonyRoot");
+    expect(result.data).toHaveProperty("workspaceRoot");
+    expect(result.data.workspaceRoot).toBe(tempDir2);
+
+    // Verify .poly_gluttony directory was created
+    const polygluttonyPath = path.join(tempDir2, ".poly_gluttony");
+    expect(fs.existsSync(polygluttonyPath)).toBe(true);
+
+    // Verify config.json was created
+    const configPath = path.join(polygluttonyPath, "config.json");
+    expect(fs.existsSync(configPath)).toBe(true);
+
+    // Cleanup
+    fs.rmSync(tempDir2, { recursive: true, force: true });
+  });
+
+  it("should get registered tools", () => {
+    const tools = orchestrator.getRegisteredTools();
+
+    expect(tools.length).toBeGreaterThan(0);
+
+    // Check that config tools are registered
+    const toolNames = tools.map((t) => t.name);
+    expect(toolNames).toContain("config-load");
+    expect(toolNames).toContain("config-init");
+    expect(toolNames).toContain("config-get");
+  });
+
+  it("should handle tool not found", async () => {
+    const result = await orchestrator.invoke("nonexistent-tool");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("Tool not found");
+  });
+});

--- a/claudine-cli/tsconfig.json
+++ b/claudine-cli/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleDetection": "force",
     "jsx": "react-jsx",
     "allowJs": true,
+    "types": ["@types/bun"],
 
     // Bundler mode
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Harvest PR

Copilot branch \copilot/integrate-config-manager-orchestrator\ adds the orchestration layer that wires the config system into CLI commands.

### What's here
- \claudine-cli/src/core/orchestrator/orchestrator.ts\ (+161 lines) — dispatch orchestrator
- \claudine-cli/src/core/detector/index.ts\ (+23 lines) — detector module
- \claudine-cli/src/core/config/index.ts\ (+88 lines) — config module exports
- \claudine-cli/tests/orchestration.test.ts\ (+87 lines) — orchestration tests

### Context
Architectural dependency on \implement-config-system-tests\ branch. These two PRs form the complete config+orchestration subsystem.

### Action needed
Review orchestrator.ts for dispatch logic — this is the architectural core.

*Wet-Paper-to-Gold archaeology.*